### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/brannondorsey/sigscan/compare/v0.2.0...v0.2.1) - 2025-05-02
+
+### Other
+
+- *(deps)* Bump nix ([#12](https://github.com/brannondorsey/sigscan/pull/12))
+
 ## [0.1.1](https://github.com/brannondorsey/sigscan/compare/v0.1.0...v0.1.1) - 2025-05-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-scan"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-scan"
-version = "0.2.0"
+version = "0.2.1"
 description = "List POSIX signal information about all processes on a host using Linux procfs"
 edition = "2024"
 authors = ["Brannon Dorsey <brannon@brannondorsey.com>"]


### PR DESCRIPTION



## 🤖 New release

* `signal-scan`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/brannondorsey/sigscan/compare/v0.2.0...v0.2.1) - 2025-05-02

### Other

- *(deps)* Bump nix ([#12](https://github.com/brannondorsey/sigscan/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).