### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/brannondorsey/sigscan/compare/v0.2.1...v0.2.2) - 2025-05-04
+
+### Other
+
+- cargo update ([#16](https://github.com/brannondorsey/sigscan/pull/16))
+- *(docs)* Update crate description ([#17](https://github.com/brannondorsey/sigscan/pull/17))
+- *(docs)* Update CHANGELOG ([#14](https://github.com/brannondorsey/sigscan/pull/14))
+
 ## [0.2.1](https://github.com/brannondorsey/sigscan/compare/v0.2.0...v0.2.1) - 2025-05-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-scan"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-scan"
-version = "0.2.1"
+version = "0.2.2"
 description = "List POSIX signal information for all processes on Linux"
 edition = "2024"
 authors = ["Brannon Dorsey <brannon@brannondorsey.com>"]


### PR DESCRIPTION



## 🤖 New release

* `signal-scan`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/brannondorsey/sigscan/compare/v0.2.1...v0.2.2) - 2025-05-04

### Other

- cargo update ([#16](https://github.com/brannondorsey/sigscan/pull/16))
- *(docs)* Update crate description ([#17](https://github.com/brannondorsey/sigscan/pull/17))
- *(docs)* Update CHANGELOG ([#14](https://github.com/brannondorsey/sigscan/pull/14))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).