### PR TITLE
feat: Add --empty flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,11 @@ sigscan --ignored
 # Show caught, blocked, pending, **and** ignored signals (equivalent to `sigscan -cbpi`)
 sigscan --caught --blocked --pending --ignored
 
-# Or use --all/-a instead of specifying all four signal types
+# Or use --all/-a instead of specifying all four signal types, plus processes with empty signal masks
 sigscan --all
+
+# Show only processes with totally empty signal masks (e.g. no signals are caught, blocked, pending, or ignored)
+sigscan --empty
 ```
 
 ### Recipes

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,7 +8,7 @@ However, any of these options you specify will override and reset the defaults.
 
 Example: sigscan -cbp
 
-You can also use --all (-a) to show all signal types at once (equivalent to -cbpi).
+You can also use --all (-a) to show all signal types at once (equivalent to -cbpie).
 
 Note: This tool only supports classic POSIX signals, not real-time signals
 (e.g. SIGRTMIN and above).
@@ -39,6 +39,10 @@ pub struct Cli {
     /// Show processes that have pending signals
     #[arg(short, long, default_value_t = true)]
     pub pending: bool,
+
+    /// Show processes that have empty signal masks
+    #[arg(short, long, default_value_t = false)]
+    pub empty: bool,
 
     /// Show all signal types (equivalent to -cbpi)
     #[arg(short, long, default_value_t = false)]
@@ -85,6 +89,7 @@ impl Cli {
             let mut has_caught = false;
             let mut has_blocked = false;
             let mut has_pending = false;
+            let mut has_empty = false;
 
             // Examine each argument
             for arg in args {
@@ -104,6 +109,9 @@ impl Cli {
                 if arg == "--pending" || short_arg_present(arg, 'p') {
                     has_pending = true;
                 }
+                if arg == "--empty" || short_arg_present(arg, 'e') {
+                    has_empty = true;
+                }
             }
 
             if has_all {
@@ -111,11 +119,13 @@ impl Cli {
                 cli.caught = true;
                 cli.blocked = true;
                 cli.pending = true;
-            } else if has_ignored || has_caught || has_blocked || has_pending {
+                cli.empty = true;
+            } else if has_ignored || has_caught || has_blocked || has_pending || has_empty {
                 cli.ignored = has_ignored;
                 cli.caught = has_caught;
                 cli.blocked = has_blocked;
                 cli.pending = has_pending;
+                cli.empty = has_empty;
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,13 +68,14 @@ fn main() {
         let blocked = format_signal_str!(cli.blocked, blocked, "blocked", |t| t.bright_red());
         let pending = format_signal_str!(cli.pending, pending, "pending", |t| t.bright_green());
 
-        let display_none =
+        let is_empty =
             ignored.is_empty() && caught.is_empty() && blocked.is_empty() && pending.is_empty();
-        if !display_none {
-            let _ = writeln!(
-                io::stdout(),
-                "{pid} {name} {ignored}{caught}{blocked}{pending}"
-            );
+
+        let display = !is_empty || cli.empty;
+        if display {
+            let output = format!("{pid} {name} {ignored}{caught}{blocked}{pending}");
+            let output = output.trim_end();
+            let _ = writeln!(io::stdout(), "{output}");
         }
     });
 }
@@ -95,6 +96,11 @@ fn get_filter_status(cli: &Cli) -> impl FnMut(&Status) -> bool {
             || (cli.blocked && status.sigblk != 0)
             || (cli.caught && status.sigcgt != 0)
             || (cli.ignored && status.sigign != 0)
+            || (cli.empty
+                && status.sigign == 0
+                && status.sigcgt == 0
+                && status.sigblk == 0
+                && status.shdpnd == 0)
     }
 }
 


### PR DESCRIPTION
This flag can be used to show processes which have empty signal masks (e.g. don't have any blocked, pending, caught, or ignored signals)

These processes will also be included when the --all flag is specified.

This feature was originally suggested in this Reddit thread: https://www.reddit.com/r/linux/comments/1kekq2x/i_built_a_cli_for_viewing_posix_signal_info_for/