### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/brannondorsey/sigscan/compare/v0.2.2...v0.2.3) - 2025-05-07
+
+### Added
+
+- Add --empty flag ([#18](https://github.com/brannondorsey/sigscan/pull/18))
+
+### Fixed
+
+- Trim trailing whitespace in output ([#19](https://github.com/brannondorsey/sigscan/pull/19))
+
+### Other
+
+- Remove more unnecessary logic in `sigset_to_strings()` ([#22](https://github.com/brannondorsey/sigscan/pull/22))
+- Remove unnecessary logic in `sigset_to_strings()` ([#21](https://github.com/brannondorsey/sigscan/pull/21))
+
 ## [0.2.2](https://github.com/brannondorsey/sigscan/compare/v0.2.1...v0.2.2) - 2025-05-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-scan"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "clap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "signal-scan"
-version = "0.2.2"
+version = "0.2.3"
 description = "List POSIX signal information for all processes on Linux"
 edition = "2024"
 authors = ["Brannon Dorsey <brannon@brannondorsey.com>"]


### PR DESCRIPTION



## 🤖 New release

* `signal-scan`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/brannondorsey/sigscan/compare/v0.2.2...v0.2.3) - 2025-05-07

### Added

- Add --empty flag ([#18](https://github.com/brannondorsey/sigscan/pull/18))

### Fixed

- Trim trailing whitespace in output ([#19](https://github.com/brannondorsey/sigscan/pull/19))

### Other

- Remove more unnecessary logic in `sigset_to_strings()` ([#22](https://github.com/brannondorsey/sigscan/pull/22))
- Remove unnecessary logic in `sigset_to_strings()` ([#21](https://github.com/brannondorsey/sigscan/pull/21))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).